### PR TITLE
Fixing CanUserCastSpell method and fixing Unit test methods

### DIFF
--- a/src/TransGr8-DD-Test/SpellChecker.cs
+++ b/src/TransGr8-DD-Test/SpellChecker.cs
@@ -1,57 +1,62 @@
 ﻿namespace TransGr8_DD_Test
 {
-	public class SpellChecker
-	{
-		private readonly List<Spell> _spellList;
+    public class SpellChecker
+    {
+        private readonly List<Spell> _spellList;
 
-		public SpellChecker(List<Spell> spells)
-		{
-			_spellList = spells;
-		}
+        public SpellChecker(List<Spell> spells)
+        {
+            _spellList = spells;
+        }
 
-		public bool CanUserCastSpell(User user, string spellName)
-		{
-			Spell spell = _spellList.Find(s => s.Name == spellName);
-			
-			if (user.Level < spell.Level)
-			{
-				return false;
-			}
-			if (spell.Components.Contains("V"))
-			{
-				if (!user.HasVerbalComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("S"))
-			{
-				if (!user.HasSomaticComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("M"))
-			{
-				if (!user.HasMaterialComponent)
-				{
-					return false;
-				}
-			}
-			if (user.Range < spell.Range)
-			{
-				return false;
-			}
-			if (spell.Duration.Contains("Concentration"))
-			{
-				if (!user.HasConcentration)
-				{
-					return false;
-				}
-			}
-			// Add additional checks as needed for specific saving throws or other requirements.
-			return true;
-		}
-		
-	}
+        public bool CanUserCastSpell(User user, string spellName)
+        {
+            Spell spell = _spellList.Find(s => s.Name == spellName);
+
+            if (spell is null)
+            {
+                return false;
+            }
+
+            if (user.Level < spell.Level)
+            {
+                return false;
+            }
+            if (spell.Components.Contains("V"))
+            {
+                if (!user.HasVerbalComponent)
+                {
+                    return false;
+                }
+            }
+            if (spell.Components.Contains("S"))
+            {
+                if (!user.HasSomaticComponent)
+                {
+                    return false;
+                }
+            }
+            if (spell.Components.Contains("M"))
+            {
+                if (!user.HasMaterialComponent)
+                {
+                    return false;
+                }
+            }
+            if (user.Range < spell.Range)
+            {
+                return false;
+            }
+            if (spell.Duration.Contains("Concentration"))
+            {
+                if (!user.HasConcentration)
+                {
+                    return false;
+                }
+            }
+            // Add additional checks as needed for specific saving throws or other requirements.
+            return true;
+        }
+
+    }
 }

--- a/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
+++ b/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
@@ -3,165 +3,175 @@
 namespace TransGr8_DD_Test.Tests
 {
 
-	[TestFixture]
-	public class SpellCheckerTests
-	{
+    [TestFixture]
+    public class SpellCheckerTests
+    {
 
 
-		private List<Spell> spells;
-		private User user;
+        private List<Spell> spells;
+        private User user;
 
-		[SetUp]
-		public void Setup()
-		{
+        [SetUp]
+        public void Setup()
+        {
 
-			spells = new List<Spell>();
-			spells.Add(new Spell
-			{
-				Name = "Fireball",
-				Level = 3,
-				CastingTime = "1 action",
-				Components = "V, S, M (a tiny ball of bat guano and sulfur)",
-				Range = 150,
-				Duration = "Instantaneous",
-				SavingThrow = "Dexterity"
-			});
-			spells.Add(new Spell
-			{
-				Name = "Magic Missile",
-				Level = 1,
-				CastingTime = "1 action",
-				Components = "V, S",
-				Range = 120,
-				Duration = "Instantaneous",
-				SavingThrow = ""
-			});
-			spells.Add(new Spell
-			{
-				Name = "Cure Wounds",
-				Level = 1,
-				CastingTime = "1 action",
-				Components = "V, S",
-				Range = 1,
-				Duration = "Instantaneous",
-				SavingThrow = ""
-			});
+            spells = new List<Spell>();
+            spells.Add(new Spell
+            {
+                Name = "Fireball",
+                Level = 3,
+                CastingTime = "1 action",
+                Components = "V, S, M (a tiny ball of bat guano and sulfur)",
+                Range = 150,
+                Duration = "Instantaneous",
+                SavingThrow = "Dexterity"
+            });
+            spells.Add(new Spell
+            {
+                Name = "Magic Missile",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V, S",
+                Range = 120,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            });
+            spells.Add(new Spell
+            {
+                Name = "Cure Wounds",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V, S",
+                Range = 1,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            });
+            spells.Add(new Spell
+            {
+                Name = "Hold Person",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V, S",
+                Range = 1,
+                Duration = "Concentration",
+                SavingThrow = ""
+            });
 
 
-			// Create a new User object with default values for testing.
-			user = new User
-			{
-				Level = 3,
-				HasVerbalComponent = true,
-				HasSomaticComponent = true,
-				HasMaterialComponent = true,
-				Range = 200,
-				HasConcentration = true
-			};
-		}
+            // Create a new User object with default values for testing.
+            user = new User
+            {
+                Level = 3,
+                HasVerbalComponent = true,
+                HasSomaticComponent = true,
+                HasMaterialComponent = true,
+                Range = 200,
+                HasConcentration = true
+            };
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsTrue()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
+        [Test]
+        public void TestCanUserCastSpellReturnsTrue()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.True(result);
-		}
+            // Assert
+            Assert.True(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForInsufficientLevel()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
-			user.Level = 2;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForInsufficientLevel()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
+            user.Level = 2;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingVerbalComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Command";
-			user.HasVerbalComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingVerbalComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Magic Missile";
+            user.HasVerbalComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingSomaticComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Cure Wounds";
-			user.HasSomaticComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingSomaticComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Cure Wounds";
+            user.HasSomaticComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingMaterialComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Identify";
-			user.HasMaterialComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingMaterialComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
+            user.HasMaterialComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForInsufficientRange()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
-			user.Range = 20;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForInsufficientRange()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
+            user.Range = 20;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingConcentration()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Hold Person";
-			user.HasConcentration = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingConcentration()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Hold Person";
+            user.HasConcentration = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
-	}
+            // Assert
+            Assert.False(result);
+        }
+    }
 }


### PR DESCRIPTION
**What?**
Fixing bug related to when user does not have "Somatic Component"

**Why?**
When the Spell is "Cure Wounds" and the User DOES NOT HAVE "Somatic Component" then they should not be able to cast the spell.

**How?**

- Modifying the CanUserCastSpell method to match the behaviour of the app.
- Modifying Unit Tests methods to cover the specific behaviour based on each method name

**Screenshots**
![image](https://user-images.githubusercontent.com/60364807/230519396-1333d2ab-f6cc-4733-8359-0402ec4c917b.png)
