### PR TITLE
Fix SpellChecker Bug

### DIFF
--- a/src/TransGr8-DD-Test/CheckerEngine.cs
+++ b/src/TransGr8-DD-Test/CheckerEngine.cs
@@ -1,0 +1,39 @@
+﻿namespace TransGr8_DD_Test
+{
+    internal interface ICheckerEngine
+    {
+        void Register(IChecker checker);
+        bool Check(User user, Spell spell);
+    }
+    internal class CheckerEngine : ICheckerEngine
+    {
+		private readonly List<IChecker> _checkers;
+
+        public CheckerEngine()
+        {
+            _checkers = new List<IChecker>();
+        }
+
+        public void Register(IChecker checker)
+		{
+			_checkers.Add(checker);
+		}
+		public bool Check(User user, Spell spell)
+        {
+            foreach (IChecker checker in _checkers)
+            {
+				if(checker.Evaluate(user, spell))
+                {
+					return false;
+                }
+            }
+			return true;
+        }
+        
+    }
+    
+	
+}
+
+
+

--- a/src/TransGr8-DD-Test/IChecker.cs
+++ b/src/TransGr8-DD-Test/IChecker.cs
@@ -1,0 +1,52 @@
+﻿namespace TransGr8_DD_Test
+{
+    internal interface IChecker
+    {
+		bool Evaluate(User user, Spell spell);
+    }
+	public class LevelChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return user.Level < spell.Level;
+		}
+	}
+	public class VerbalComponentChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return spell.Components.Contains("V") && !user.HasVerbalComponent;
+		}
+	}
+	public class SomaticComponentChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return spell.Components.Contains("S") && !user.HasSomaticComponent;
+		}
+	}
+	public class MaterialComponentChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return spell.Components.Contains("M") && !user.HasMaterialComponent;
+		}
+	}
+	public class RangeChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return user.Range < spell.Range;
+		}
+	}
+	public class ConcentrationChecker : IChecker
+	{
+		public bool Evaluate(User user, Spell spell)
+		{
+			return spell.Duration.Contains("Concentration") && !user.HasConcentration;
+		}
+	}
+}
+
+
+

--- a/src/TransGr8-DD-Test/SpellChecker.cs
+++ b/src/TransGr8-DD-Test/SpellChecker.cs
@@ -1,57 +1,31 @@
 ﻿namespace TransGr8_DD_Test
 {
-	public class SpellChecker
+    public class SpellChecker
 	{
-		private readonly List<Spell> _spellList;
+		private readonly ISpellRepository _spellRepository;
 
-		public SpellChecker(List<Spell> spells)
+		internal SpellChecker(List<Spell> spells)
 		{
-			_spellList = spells;
+			_spellRepository = new SpellRepository(spells);
 		}
 
 		public bool CanUserCastSpell(User user, string spellName)
 		{
-			Spell spell = _spellList.Find(s => s.Name == spellName);
-			
+			Spell spell = _spellRepository.GetSpell(spellName);
 			if (user.Level < spell.Level)
-			{
 				return false;
-			}
-			if (spell.Components.Contains("V"))
-			{
-				if (!user.HasVerbalComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("S"))
-			{
-				if (!user.HasSomaticComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("M"))
-			{
-				if (!user.HasMaterialComponent)
-				{
-					return false;
-				}
-			}
+			if (!user.HasVerbalComponent && spell.Components.Contains("V"))
+				return false;
+			if (!user.HasSomaticComponent && spell.Components.Contains("S"))
+				return false;
+			if (!user.HasMaterialComponent && spell.Components.Contains("M"))
+				return false;
 			if (user.Range < spell.Range)
-			{
 				return false;
-			}
-			if (spell.Duration.Contains("Concentration"))
-			{
-				if (!user.HasConcentration)
-				{
-					return false;
-				}
-			}
+			if (!user.HasConcentration && spell.Duration.Contains("Concentration"))
+				return false;
 			// Add additional checks as needed for specific saving throws or other requirements.
 			return true;
 		}
-		
 	}
 }

--- a/src/TransGr8-DD-Test/SpellNotFoundException.cs
+++ b/src/TransGr8-DD-Test/SpellNotFoundException.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.Serialization;
+
+namespace TransGr8_DD_Test
+{
+    internal class SpellNotFoundException : Exception
+    {
+        public SpellNotFoundException()
+        {
+        }
+
+        public SpellNotFoundException(string message) : base(message)
+        {
+        }
+
+        public SpellNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected SpellNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/SpellRepository.cs
+++ b/src/TransGr8-DD-Test/SpellRepository.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Immutable;
+
+namespace TransGr8_DD_Test
+{
+    internal interface ISpellRepository
+    {
+        Spell GetSpell(string spellName);
+    }
+    internal class SpellRepository : ISpellRepository
+    {
+		private readonly ImmutableArray<Spell> _spellList;
+        public SpellRepository(List<Spell> spellList)
+        {
+            _spellList = spellList.ToImmutableArray();
+        }
+        public Spell GetSpell(string spellName)
+        {
+            return _spellList.FirstOrDefault(spell => String.Equals(spell.Name, spellName)) ?? throw new SpellNotFoundException($"{spellName} Spell is not found");
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
+++ b/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
@@ -46,8 +46,36 @@ namespace TransGr8_DD_Test.Tests
 				Duration = "Instantaneous",
 				SavingThrow = ""
 			});
-
-
+			spells.Add(new Spell
+			{
+				Name = "Command",
+				Level = 1,
+				CastingTime = "1 action",
+				Components = "V",
+				Range = 1,
+				Duration = "Instantaneous",
+				SavingThrow = ""
+			});
+			spells.Add(new Spell
+			{
+				Name = "Identify",
+				Level = 1,
+				CastingTime = "1 action",
+				Components = "M",
+				Range = 1,
+				Duration = "Instantaneous",
+				SavingThrow = ""
+			});
+			spells.Add(new Spell
+			{
+				Name = "Hold Person",
+				Level = 1,
+				CastingTime = "1 action",
+				Components = "M, V, S",
+				Range = 1,
+				Duration = "Concentration",
+				SavingThrow = ""
+			});
 			// Create a new User object with default values for testing.
 			user = new User
 			{
@@ -162,6 +190,16 @@ namespace TransGr8_DD_Test.Tests
 
 			// Assert
 			Assert.False(result);
+		}
+		[Test]
+		public void TestCanUserCastSpellThrowsSpellNotFoundExceptionForMissingSpells()
+		{
+			// Arrange
+			SpellChecker spellChecker = new SpellChecker(spells);
+			var spellName = Guid.NewGuid().ToString()[..6];
+			// Act
+			// Assert
+			Assert.Throws<SpellNotFoundException>(() => spellChecker.CanUserCastSpell(user, spellName));
 		}
 	}
 }


### PR DESCRIPTION
### Description
This PR Fixes a bug reported in Spells retrieval logic when the Spell is not found, also it addresses several design issues in the code concerning hard-coupled services for Spell checking. 

We have implemented two major services CheckerEngine following Rules Engine Design and SpellsRepository allowing us to separate Spells retrieval from SpellChecker logic, this allowed us to have more cohesive and low-coupled code.

### Changes
Added ICheckerEngine, IChecker, and  ISpellRepository service with the corresponding implementation.
Add Test cases to handle not found spells cases.
Add Spells to cover failing test cases.
