### PR TITLE
SpellChecker bug fix and refactoring

### DIFF
--- a/src/TransGr8-DD-Test/Data/users.json
+++ b/src/TransGr8-DD-Test/Data/users.json
@@ -1,0 +1,66 @@
+[
+  {
+    "Level": 3,
+    "HasVerbalComponent": true,
+    "HasSomaticComponent": true,
+    "HasMaterialComponent": true,
+    "HasConcentration": true,
+    "Range": 200
+  },
+  {
+    "level": 4,
+    "hasVerbalComponent": true,
+    "hasSomaticComponent": false,
+    "hasMaterialComponent": false,
+    "hasConcentration": false,
+    "range": 300
+  },
+  {
+    "level": 1,
+    "hasVerbalComponent": true,
+    "hasSomaticComponent": true,
+    "hasMaterialComponent": false,
+    "hasConcentration": true,
+    "range": 500
+  },
+  {
+    "level": 1,
+    "hasVerbalComponent": true,
+    "hasSomaticComponent": false,
+    "hasMaterialComponent": false,
+    "hasConcentration": true,
+    "range": 400
+  },
+  {
+    "level": 2,
+    "hasVerbalComponent": true,
+    "hasSomaticComponent": false,
+    "hasMaterialComponent": true,
+    "hasConcentration": true,
+    "range": 300
+  },
+  {
+    "level": 3,
+    "hasVerbalComponent": false,
+    "hasSomaticComponent": true,
+    "hasMaterialComponent": false,
+    "hasConcentration": true,
+    "range": 400
+  },
+  {
+    "level": 4,
+    "hasVerbalComponent": false,
+    "hasSomaticComponent": true,
+    "hasMaterialComponent": true,
+    "hasConcentration": false,
+    "range": 300
+  },
+  {
+    "level": 2,
+    "hasVerbalComponent": true,
+    "hasSomaticComponent": true,
+    "hasMaterialComponent": true,
+    "hasConcentration": true,
+    "range": 200
+  }
+]

--- a/src/TransGr8-DD-Test/Interfaces/ISpellNameRule.cs
+++ b/src/TransGr8-DD-Test/Interfaces/ISpellNameRule.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static TransGr8_DD_Test.Rules.CanUserCastSpellEngine;
+
+namespace TransGr8_DD_Test.Interfaces
+{
+    internal interface ISpellNameRule
+    {
+        public bool UserCanCastSpell(User user, Spell spell);
+        public RulesOrder Type { get; }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellEngine.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellEngine.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellEngine
+    {
+        private readonly IEnumerable<ISpellNameRule> _rules;
+        public enum RulesOrder
+        {
+            CanUserCastSpellForInsufficientLevel,
+            CanUserCastSpellForMissingVerbalComponentRule,
+            CanUserCastSpellForMissingSomaticComponentRule,
+            CanUserCastSpellForMissingMaterialComponentRule,
+            CanUserCastSpellForInsufficientRange,
+            CanUserCastSpellForMissingConcentration
+        }
+
+        public CanUserCastSpellEngine() 
+        {
+            _rules = GetRules();
+        }
+
+        private static IEnumerable< ISpellNameRule> GetRules()
+        {
+            var type = typeof(ISpellNameRule);
+            var rules = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(item => type.IsAssignableFrom(item) && !item.IsInterface)
+                .Select(item=>(ISpellNameRule)Activator
+                .CreateInstance(item))
+                .OrderBy(item => item.Type)
+                .ToList();
+            return rules;
+        }
+
+        public bool Evaluate(User user, Spell spell)
+        {
+            foreach (var rule in _rules)
+            {
+                if(!rule.UserCanCastSpell(user, spell))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForInsufficientLevelRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForInsufficientLevelRule.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForInsufficientLevelRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForInsufficientLevel;
+
+        public bool UserCanCastSpell(User user, Spell spell)
+        {
+            if (user.Level < spell.Level)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForInsufficientRangeRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForInsufficientRangeRule.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForInsufficientRangeRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForInsufficientRange;
+
+        public bool UserCanCastSpell(User user, Spell spell)
+        {
+            if (user.Range < spell.Range)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingConcentrationRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingConcentrationRule.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForMissingConcentrationRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForMissingConcentration;
+
+        public bool UserCanCastSpell(User user, Spell spell)
+        {
+            if (spell.Duration.Contains("Concentration"))
+            {
+                if (!user.HasConcentration)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingMaterialComponentRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingMaterialComponentRule.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForMissingMaterialComponentRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForMissingMaterialComponentRule;
+
+        public bool UserCanCastSpell(User user, Spell spell)
+        {
+            if (spell.Components.Contains("M"))
+            {
+                if (!user.HasMaterialComponent)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingSomaticComponentRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingSomaticComponentRule.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForMissingSomaticComponentRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForMissingSomaticComponentRule;
+
+        bool ISpellNameRule.UserCanCastSpell(User user, Spell spell)
+        {
+            if (spell.Components.Contains("S"))
+            {
+                if (!user.HasSomaticComponent)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingVerbalComponentRule.cs
+++ b/src/TransGr8-DD-Test/Rules/CanUserCastSpellForMissingVerbalComponentRule.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TransGr8_DD_Test.Interfaces;
+
+namespace TransGr8_DD_Test.Rules
+{
+    internal class CanUserCastSpellForMissingVerbalComponentRule : ISpellNameRule
+    {
+        public CanUserCastSpellEngine.RulesOrder Type => CanUserCastSpellEngine.RulesOrder.CanUserCastSpellForMissingVerbalComponentRule;
+
+        public bool UserCanCastSpell(User user, Spell spell)
+        {
+
+            if (spell.Components.Contains("V"))
+            {
+                if (!user.HasVerbalComponent)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Services/LoggerService.cs
+++ b/src/TransGr8-DD-Test/Services/LoggerService.cs
@@ -1,0 +1,18 @@
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TransGr8_DD_Test.Services
+{
+    internal class LoggerService
+    {
+        public LoggerService()
+        {
+            //Configure the Logger
+            Log.Logger = new LoggerConfiguration().WriteTo.File("Logs.log").CreateLogger();
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Services/SpellService.cs
+++ b/src/TransGr8-DD-Test/Services/SpellService.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TransGr8_DD_Test.Services
+{
+    internal class SpellService
+    {
+        public static List<Spell> GetSpells()
+        {
+            var spells = new List<Spell>();
+            spells.Add(new Spell
+            {
+                Name = "Fireball",
+                Level = 3,
+                CastingTime = "1 action",
+                Components = "V, S, M (a tiny ball of bat guano and sulfur)",
+                Range = 150,
+                Duration = "Instantaneous",
+                SavingThrow = "Dexterity"
+            });
+            spells.Add(new Spell
+            {
+                Name = "Magic Missile",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V, S",
+                Range = 120,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            });
+            spells.Add(new Spell
+            {
+                Name = "Cure Wounds",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V, S",
+                Range = 1,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            });
+            spells.Add(new Spell
+            {
+                Name = "Identify",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "I, M",
+                Range = 1,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            }); 
+            spells.Add(new Spell
+            {
+                Name = "Command",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V",
+                Range = 1,
+                Duration = "Instantaneous",
+                SavingThrow = ""
+            });
+            spells.Add(new Spell
+            {
+                Name = "Hold Person",
+                Level = 1,
+                CastingTime = "1 action",
+                Components = "V",
+                Range = 1,
+                Duration = "Concentration",
+                SavingThrow = ""
+            });
+            return spells;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/Services/UserService.cs
+++ b/src/TransGr8-DD-Test/Services/UserService.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TransGr8_DD_Test.Services
+{
+    internal class UserService
+    {
+        public static List<User> GetUsers()
+        {
+            try
+            {
+                Log.Information(Directory.GetCurrentDirectory());
+                StreamReader r = new StreamReader(@"Data\\users.json");
+                string json = r.ReadToEnd();
+                List<User> users = JsonConvert.DeserializeObject<List<User>>(json);
+                return users;
+            }
+            catch (DirectoryNotFoundException dfe)
+            {
+                Log.Error(dfe.Message);
+            }
+            return null;
+        }
+    }
+}

--- a/src/TransGr8-DD-Test/SpellChecker.cs
+++ b/src/TransGr8-DD-Test/SpellChecker.cs
@@ -1,57 +1,23 @@
-﻿namespace TransGr8_DD_Test
+﻿using Serilog;
+using TransGr8_DD_Test.Rules;
+
+namespace TransGr8_DD_Test
 {
-	public class SpellChecker
-	{
-		private readonly List<Spell> _spellList;
+    public class SpellChecker
+    {
+        private readonly List<Spell> _spellList;
 
-		public SpellChecker(List<Spell> spells)
-		{
-			_spellList = spells;
-		}
+        public SpellChecker(List<Spell> spells)
+        {
+            _spellList = spells;
+        }
 
-		public bool CanUserCastSpell(User user, string spellName)
-		{
-			Spell spell = _spellList.Find(s => s.Name == spellName);
-			
-			if (user.Level < spell.Level)
-			{
-				return false;
-			}
-			if (spell.Components.Contains("V"))
-			{
-				if (!user.HasVerbalComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("S"))
-			{
-				if (!user.HasSomaticComponent)
-				{
-					return false;
-				}
-			}
-			else if (spell.Components.Contains("M"))
-			{
-				if (!user.HasMaterialComponent)
-				{
-					return false;
-				}
-			}
-			if (user.Range < spell.Range)
-			{
-				return false;
-			}
-			if (spell.Duration.Contains("Concentration"))
-			{
-				if (!user.HasConcentration)
-				{
-					return false;
-				}
-			}
-			// Add additional checks as needed for specific saving throws or other requirements.
-			return true;
-		}
-		
-	}
+        public bool CanUserCastSpell(User user, string spellName)
+        {
+            Spell spell = _spellList.Find(s => s.Name == spellName);
+            CanUserCastSpellEngine canUserCastSpellEngine = new CanUserCastSpellEngine();
+            return canUserCastSpellEngine.Evaluate(user, spell);
+        }
+
+    }
 }

--- a/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
+++ b/src/TransGr8-DD-Test/Tests/SpellCheckerTests.cs
@@ -1,167 +1,134 @@
 ﻿using NUnit.Framework;
+using Serilog;
+using TransGr8_DD_Test.Services;
 
 namespace TransGr8_DD_Test.Tests
 {
 
-	[TestFixture]
-	public class SpellCheckerTests
-	{
+    [TestFixture]
+    public class SpellCheckerTests
+    {
 
 
-		private List<Spell> spells;
-		private User user;
+        private List<Spell> spells;
+        private User user;
 
-		[SetUp]
-		public void Setup()
-		{
+        [SetUp]
+        public void Setup()
+        {
+            LoggerService loggerService = new LoggerService();
+            Log.Information("This is a log test");
 
-			spells = new List<Spell>();
-			spells.Add(new Spell
-			{
-				Name = "Fireball",
-				Level = 3,
-				CastingTime = "1 action",
-				Components = "V, S, M (a tiny ball of bat guano and sulfur)",
-				Range = 150,
-				Duration = "Instantaneous",
-				SavingThrow = "Dexterity"
-			});
-			spells.Add(new Spell
-			{
-				Name = "Magic Missile",
-				Level = 1,
-				CastingTime = "1 action",
-				Components = "V, S",
-				Range = 120,
-				Duration = "Instantaneous",
-				SavingThrow = ""
-			});
-			spells.Add(new Spell
-			{
-				Name = "Cure Wounds",
-				Level = 1,
-				CastingTime = "1 action",
-				Components = "V, S",
-				Range = 1,
-				Duration = "Instantaneous",
-				SavingThrow = ""
-			});
+            //Get the list of spells from the spells service instead of having their definition here
+            spells = SpellService.GetSpells();
 
 
-			// Create a new User object with default values for testing.
-			user = new User
-			{
-				Level = 3,
-				HasVerbalComponent = true,
-				HasSomaticComponent = true,
-				HasMaterialComponent = true,
-				Range = 200,
-				HasConcentration = true
-			};
-		}
+            // Get a user from User service and pick one for testing
+            user = UserService.GetUsers()[0];
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsTrue()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
+        [Test]
+        public void TestCanUserCastSpellReturnsTrue()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.True(result);
-		}
+            // Assert
+            Assert.True(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForInsufficientLevel()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
-			user.Level = 2;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForInsufficientLevel()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
+            user.Level = 2;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingVerbalComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Command";
-			user.HasVerbalComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingVerbalComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Command";
+            user.HasVerbalComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingSomaticComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Cure Wounds";
-			user.HasSomaticComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingSomaticComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Cure Wounds";
+            user.HasSomaticComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingMaterialComponent()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Identify";
-			user.HasMaterialComponent = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingMaterialComponent()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Identify";
+            user.HasMaterialComponent = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForInsufficientRange()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Fireball";
-			user.Range = 20;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForInsufficientRange()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Fireball";
+            user.Range = 20;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
+            // Assert
+            Assert.False(result);
+        }
 
-		[Test]
-		public void TestCanUserCastSpellReturnsFalseForMissingConcentration()
-		{
-			// Arrange
-			SpellChecker spellChecker = new SpellChecker(spells);
-			string spellName = "Hold Person";
-			user.HasConcentration = false;
+        [Test]
+        public void TestCanUserCastSpellReturnsFalseForMissingConcentration()
+        {
+            // Arrange
+            SpellChecker spellChecker = new SpellChecker(spells);
+            string spellName = "Hold Person";
+            user.HasConcentration = false;
 
-			// Act
-			bool result = spellChecker.CanUserCastSpell(user, spellName);
+            // Act
+            bool result = spellChecker.CanUserCastSpell(user, spellName);
 
-			// Assert
-			Assert.False(result);
-		}
-	}
+            // Assert
+            Assert.False(result);
+        }
+    }
 }

--- a/src/TransGr8-DD-Test/TransGr8-DD-Test.csproj
+++ b/src/TransGr8-DD-Test/TransGr8-DD-Test.csproj
@@ -14,6 +14,14 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+		<PackageReference Include="Serilog" Version="2.12.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="Data\users.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
**_Bug identification_**: when the spell name is 'Cure Wounds' the component contains not only 'S' but also 'V' which make the first condition true and since we have the else statement, the condition for missing somatic component will never be evaluated.

**_New dev_**: Implementation of a rule engine that will evaluate every condition and respects the order of execution.

**_Refactoring_**: add services to get data like users and spells lists instead of the hardcoded ones.

**_Unit tests_**: adding additional spells to cover the failing tests (can be done also by checking if the spell exists or not).
